### PR TITLE
Enter key to behave like tab index

### DIFF
--- a/webclient/components/def-processors/change/add-form.vue
+++ b/webclient/components/def-processors/change/add-form.vue
@@ -152,6 +152,7 @@
                 :placeholder="propFieldDef.fieldNameInUi"
                 :value="mfGetFldValue(ormRow.clientSideUniqRowId, propFieldDef.fieldNameInDb)"
                 @input="mfSetFldValueUsingCache($event, ormRow.clientSideUniqRowId, propFieldDef.fieldNameInDb)"
+                @keydown.enter.native="mfForTabActionByEnter"
               ></el-input>
             </div>
           </div>
@@ -336,6 +337,19 @@ export default {
   methods: {
     log(item) {
       console.log(item)
+    },
+
+    mfForTabActionByEnter: function(e) {
+        // Finding cuurrent node and checking if it is textarea as this function is calling from same place for input and textarea, if it is textarea, we leave textarea to to do its own functionlity by pressing enter. otherwise for input enter ascts as tab.
+        const currentNode = e.target;
+        if(currentNode.tagName!="TEXTAREA"){
+          //Isolating the node that we're after to put focus on that node.
+          const inputs = Array.from(document.querySelectorAll('input[type="text"],textarea'));
+          const index = inputs.indexOf(e.target);
+          if (index < inputs.length) {
+            inputs[index + 1].focus();
+          }
+      }  
     },
 
     mfGetArOfDataRows() {

--- a/webclient/components/def-processors/change/edit-form.vue
+++ b/webclient/components/def-processors/change/edit-form.vue
@@ -78,6 +78,7 @@
               :autosize="{ minRows: 2, maxNumberOfRows: 4 }"
               :value="mfGetCopiedRowBeingChangedFldVal(propFieldDef.fieldNameInDb)"
               @input="mfSetCopiedRowBeingChangedFldVal($event, propFieldDef.fieldNameInDb)"
+              @keydown.enter.native="mfForTabActionByEnter"
               @focus="showHistoryOnFocus = true"
               @blue="showHistoryOnFocus = false"
             ></el-input>
@@ -322,6 +323,18 @@ export default {
         rowStatus
       )
       this.$forceUpdate() // Not able to remove it. For the different methods tried read: cts/def-processors/crud/manage-rows-of-table-in-client-side-orm.js:133/fnPutFldValueInCache
+    },
+    mfForTabActionByEnter: function(e) {
+        // Finding cuurrent node and checking if it is textarea as this function is calling from same place for input and textarea, if it is textarea, we leave textarea to to do its own functionlity by pressing enter. otherwise for input enter ascts as tab.
+        const currentNode = e.target;
+        if(currentNode.tagName!="TEXTAREA"){
+          //Isolate the node that we're after to put focus on that node.
+          const inputs = Array.from(document.querySelectorAll('input[type="text"],textarea'));
+          const index = inputs.indexOf(e.target);
+          if (index < inputs.length) {
+            inputs[index + 1].focus();
+          }
+      }  
     },
   },
 }


### PR DESCRIPTION
Ref for https://github.com/savantcare/emr/pull/242

https://stackoverflow.com/questions/2523752/behavior-of-enter-key-in-textbox

According to this article and me, in our application, enter should act as tab for single line text field only, for textarea or multiple line text field, cursor should come to next line by pressing enter. Like textarea other html tags have default behaviour for enter.